### PR TITLE
Check for bugs

### DIFF
--- a/lib/firebase/conversations.ts
+++ b/lib/firebase/conversations.ts
@@ -1,4 +1,4 @@
-import { excludeKeys, xKeys } from '@/ctx/chat/helpers'
+import { xKeys } from '@/ctx/chat/helpers'
 import { Message } from 'ai'
 import {
   collection,
@@ -47,9 +47,15 @@ export async function createConversation({
 export async function addMessage({ convId, message }: AddMessageParams) {
   // logFirestoreArgs('addMessage', 'conversations', convId, 'messages', id)
   const ref = doc(db, 'conversations', convId, 'messages', message.id)
-  // console.log('[Firestore] addMessage called with:', { id, convId, ...rest })
+  console.log('[Firestore] addMessage called with:', { 
+    convId, 
+    messageId: message.id,
+    role: message.role,
+    contentLength: message.content?.length,
+    hasContent: !!message.content
+  })
   await setDoc(ref, createPayload(message, 'timestamp'))
-  // console.log('[Firestore] addMessage write complete for:', id)
+  console.log('[Firestore] addMessage write complete for:', message.id, 'role:', message.role)
 }
 
 export async function getConversation(convId: string) {
@@ -83,7 +89,7 @@ export async function getRecentConversationsForUser(userId: string, n = 10) {
   const ref = collection(db, 'conversations')
   const q = query(
     ref,
-    where(userId, '==', 'userId'),
+    where('userId', '==', userId),
     orderBy('createdAt', 'desc'),
     limit(n)
   )


### PR DESCRIPTION
Several bugs were identified and addressed to resolve issues with assistant messages not being saved to Firestore:

*   A stale closure issue in `useConversation.ts`'s `handleSubsequentMessage` was fixed. The `convId` dependency was removed, and a `useRef` (`convIdRef`) was introduced to ensure the callback always accesses the current `convId`, preventing messages from being saved with an outdated or null conversation ID.
*   Variable shadowing in `useConversation.ts`'s `handleFirstMessage` was resolved by renaming a local `convId` variable to `newConvId`, improving code clarity.
*   An incorrect Firestore query in `lib/firebase/conversations.ts`'s `getRecentConversationsForUser` was corrected. The `where` clause arguments were reversed (`where(userId, '==', 'userId')` changed to `where('userId', '==', userId)`), ensuring conversations are correctly fetched for the specified user.
*   Redundant `convId` initialization in `useConversation.ts`'s `handleFirstMessage` was removed for cleaner code.
*   Detailed `console.log` statements were added in `lib/firebase/conversations.ts`'s `addMessage` and `useConversation.ts`'s `handleSubsequentMessage` to provide better visibility into the message saving process.