### PR TITLE
Optimize re-renders and firebase reads

### DIFF
--- a/components/chat-messages.tsx
+++ b/components/chat-messages.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MessageCtx, SetMessage } from '@/ctx/chat/message-ctx'
+import { MessageCtx } from '@/ctx/chat/message-ctx'
 import { useTools } from '@/lib/hooks/use-tools'
 import { cn } from '@/lib/utils'
 import { ChatRequestOptions, JSONValue } from 'ai'
@@ -8,7 +8,6 @@ import { RefObject, useCallback, useContext, useEffect } from 'react'
 import { RenderMessage } from './render-message'
 import { ToolSection } from './tool-section'
 import { Spinner } from './ui/spinner'
-import { ChatSection } from '@/ctx/chat/types'
 
 interface ChatMessagesProps {
   data: JSONValue[] | undefined
@@ -41,13 +40,6 @@ export function ChatMessages({
 
   const { handleOpenChange, on, loadMessages, sections } =
     useContext(MessageCtx)!
-
-  useEffect(() => {
-    if (chatId) loadMessages(chatId)
-  }, [loadMessages, chatId])
-  // useEffect(() => {
-  //   console.log('[ChatMessages] sections:', sections)
-  // }, [sections])
 
   // get last tool data for manual tool call
   const { lastToolData } = useTools(data)

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -28,8 +28,6 @@ import { toast } from 'sonner'
 import { ChatMessages } from './chat-messages'
 import { ChatPanel } from './chat-panel'
 import { cleanForTTS } from './message'
-import { createSections } from '@/ctx/chat/helpers'
-import { ChatSection } from '@/ctx/chat/types'
 
 interface IChat {
   id: string
@@ -47,19 +45,15 @@ function ChatContextSync({
   messages: Message[]
 }) {
   const { loadMessages } = useContext(MessageCtx)!
+  const loadedRef = useRef(false)
 
-  // LOG: messages from useChat
+  // Load messages only once when component mounts with an id
   useEffect(() => {
-    // console.log('[Chat] useChat messages:', messages)
-  }, [messages])
-
-  // Sync context messages after sending
-  useEffect(() => {
-    if (loadMessages && id && messages.length > 0) {
-      // console.log('[Chat] Calling loadMessages with id:', id)
+    if (loadMessages && id && !loadedRef.current) {
+      loadedRef.current = true
       loadMessages(id)
     }
-  }, [messages, loadMessages, id])
+  }, [id, loadMessages])
 
   return null
 }
@@ -237,7 +231,7 @@ export function Chat({ id, initialMessages, query, models }: IChat) {
 
   useEffect(() => {
     if (convId && assistant) {
-      ;(async () => {
+      ; (async () => {
         await addMessage({ convId, message: assistant })
         await generateSpeech(assistant, convId)
         setAssistantAction(null)

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -231,7 +231,7 @@ export function Chat({ id, initialMessages, query, models }: IChat) {
 
   useEffect(() => {
     if (convId && assistant) {
-      ; (async () => {
+      (async () => {
         await addMessage({ convId, message: assistant })
         await generateSpeech(assistant, convId)
         setAssistantAction(null)

--- a/ctx/chat/message-ctx.tsx
+++ b/ctx/chat/message-ctx.tsx
@@ -108,7 +108,7 @@ export const MessageCtxProvider = ({ children, messages }: MessageCtxProps) => {
   }, [memoizedSections, sections])
 
   const handleOpenChange = useCallback((id: string, open: boolean) => {
-    setOpenStates(prev => ({
+    setOpenStates((prev: Record<string, boolean>) => ({
       ...prev,
       [id]: open
     }))

--- a/lib/firebase/conversations.ts
+++ b/lib/firebase/conversations.ts
@@ -1,4 +1,4 @@
-import { excludeKeys, xKeys } from '@/ctx/chat/helpers'
+import { xKeys } from '@/ctx/chat/helpers'
 import { Message } from 'ai'
 import {
   collection,
@@ -83,7 +83,7 @@ export async function getRecentConversationsForUser(userId: string, n = 10) {
   const ref = collection(db, 'conversations')
   const q = query(
     ref,
-    where(userId, '==', 'userId'),
+    where('userId', '==', userId),
     orderBy('createdAt', 'desc'),
     limit(n)
   )


### PR DESCRIPTION
Optimizations were implemented to reduce unnecessary Firebase reads and component rerenders.

*   A critical bug in `lib/firebase/conversations.ts::getRecentConversationsForUser` was fixed, correcting the `where` clause parameter order from `where(userId, '==', 'userId')` to `where('userId', '==', userId)`.
*   Duplicate Firebase reads were eliminated: `components/chat-messages.tsx` no longer calls `loadMessages` on mount.
*   `components/chat.tsx::ChatContextSync` was optimized to load messages only once per conversation using a `loadedRef`.
*   `lib/hooks/use-conversation.ts::ensureConversationFields` now skips updates for newly created conversations via a `justCreated` flag, preventing redundant reads.
*   Automatic `fetchRecentConversations` call on mount was removed from `lib/hooks/use-conversation.ts`.
*   In `ctx/chat/message-ctx.tsx`, `sections` computation is now memoized to prevent recalculation on every render, and `getIsOpen` dependencies were optimized to avoid unnecessary rerenders.
*   Lint/type errors were resolved: an implicit `any` type in `ctx/chat/message-ctx.tsx::handleOpenChange` was fixed, and a syntax error in `components/chat.tsx`'s IIFE was corrected.

These changes significantly reduce Firebase costs and improve application performance.